### PR TITLE
Add missing handwritten blog post Markdown file

### DIFF
--- a/_posts/2026-06-19-handwritten-blogs.md
+++ b/_posts/2026-06-19-handwritten-blogs.md
@@ -1,0 +1,8 @@
+---
+layout: post
+title: "Authenticity and Handwritten Blogs"
+categories: development
+tags: handwriting, blog, image
+---
+
+![Handwritten blog post](/images/2026-06-19-handwritten-blogs.jpg)


### PR DESCRIPTION
## Summary
- Add missing Markdown post file `_posts/2026-06-19-handwritten-blogs.md` for PR #153
- The image `images/2026-06-19-handwritten-blogs.jpg` was merged but the corresponding blog post was not included in the final merge commit

## Details
The handwritten blog post Markdown file was created on the `handwritten` branch (commit 703fd19) and had its title updated (commit 4c51d2d), but was not present in the final merge commit 6356640.

This PR adds the missing file with the final title: "Authenticity and Handwritten Blogs"
