### PR TITLE
Fix issue #155: Make images responsive on mobile homepage

### DIFF
--- a/theme/css/main.css
+++ b/theme/css/main.css
@@ -518,4 +518,13 @@ li:last-child .hentry, #content > .hentry {border: 0; margin: 0;}
         word-wrap: break-word;
         overflow-x: auto;
     }
+
+    /* Fix for issue #155: Make images on homepage responsive on mobile */
+    .articles-list img,
+    #featured img {
+        max-width: 100%;
+        height: auto;
+        display: block;
+        margin: 0 auto;
+    }
 }


### PR DESCRIPTION
## Summary
- Fix issue #155: Authenticity and Handwritten Blogs looks terrible on the home page on mobile

## Changes
- Add mobile-responsive CSS rules for images in `.articles-list` and `#featured` sections
- Images now scale to `max-width: 100%` with `height: auto` on screens ≤ 768px
- Images are centered with `margin: 0 auto` on mobile

## Fixes
Fixes #155
